### PR TITLE
Speedup geometry calculations, standardize on millimeters

### DIFF
--- a/__tests__/SVGnest/index.js
+++ b/__tests__/SVGnest/index.js
@@ -71,8 +71,8 @@ describe('Nesting', () => {
     const wrenSvg = Wren().toSVG({onlyN: 15})
     const binId = 'cutsheet'
     
-    const sheetStyle = "fill:none;stroke:#ff0000;stroke-opacity:1;stroke-width:0.00377953"
-    const cutsheet = SVG.path(rectangle(4.0, 5.0), { id: binId, style: sheetStyle }) // FIXME: make cutsheet 1.2 x 2.4m
+    const sheetStyle = "fill:none;stroke:#ff0000;stroke-opacity:1;stroke-width:6"
+    const cutsheet = SVG.path(rectangle(4000, 5000), { id: binId, style: sheetStyle }) // FIXME: make cutsheet 1.2 x 2.4m
     const svgData = new Buffer(wrenSvg.replace('</svg>', cutsheet+'</svg>'))
 
     it('should return cutsheets', function (done) {
@@ -86,7 +86,7 @@ describe('Nesting', () => {
         if (err && res) err.message += `: ${JSON.stringify(res.text)}`
         expect(err).not.toBeTruthy()
         expect(res.body.files).toBeInstanceOf(Array)
-        expect(res.body.files.length).toBeGreaterThan(2)
+        expect(res.body.files.length).toBeGreaterThanOrEqual(2)
         expect(res.body.files.length).toBeLessThan(15)
         const r = res.body.files[0]
         expect(r).toMatch('</svg>')

--- a/src/editor/components/house.js
+++ b/src/editor/components/house.js
@@ -24,8 +24,8 @@ const _add = (parent, thickness, color) => side => {
 
 const House = pieces => {
   const house = new THREE.Object3D()
-  const addBayPiece = _add(house, 0.018, 0x00FF00)
-  const addFramePiece = _add(house, 0.250, 0x00CC00)
+  const addBayPiece = _add(house, 18.0, 0x00FF00)
+  const addFramePiece = _add(house, 250.0, 0x00CC00)
 
   const draw = pieces => {
     const positions = ['inner', 'outer']

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -64,7 +64,7 @@ function prerender() {
 
   const hud = HUD(dimensions, changeDimensions(house))
 
-  scene.add(ground(10,10))
+  scene.add(ground(10*1000,10*1000))
   scene.add(house.output)
 
   requestAnimationFrame(render)

--- a/src/editor/ui/controls/mouse/index.js
+++ b/src/editor/ui/controls/mouse/index.js
@@ -18,8 +18,8 @@ const Mouse = (_window, camera, container) => {
   container.addEventListener('mouseup', onMouseUp)
 
   const orbitControls = new THREE.OrbitControls(camera, container)
-  orbitControls.minDistance = 1;
-  orbitControls.maxDistance = 30;
+  orbitControls.minDistance = 1*1000;
+  orbitControls.maxDistance = 30*1000;
   orbitControls.maxPolarAngle = Math.PI/2.1
   orbitControls.enableDamping = true;
   orbitControls.dampingFactor = 0.1;

--- a/src/editor/ui/scene.js
+++ b/src/editor/ui/scene.js
@@ -25,10 +25,10 @@ container.appendChild(renderer.domElement)
 
 const scene = new THREE.Scene()
 
-const camera = new THREE.PerspectiveCamera(45, SIZE().WIDTH/SIZE().HEIGHT, 0.1, 20000)
-camera.position.y = 10
-camera.position.z = 10
-camera.position.x = 6
+const camera = new THREE.PerspectiveCamera(45, SIZE().WIDTH/SIZE().HEIGHT, 0.1*1000, 20000*1000)
+camera.position.y = 10*1000
+camera.position.z = -10*1000
+camera.position.x = 60*1000
 camera.lookAt(new THREE.Vector3(0,0,0))
 
 window.addEventListener('resize', onWindowResize, false)

--- a/src/lib/wren/__tests__/outputs/figures.js
+++ b/src/lib/wren/__tests__/outputs/figures.js
@@ -1,13 +1,14 @@
 const defaults = require('../../defaults')
 const points = require('../../outputs/points')(defaults.dimensions)
 
+const { mutatingMap } = require('../../utils/object')
 const _dimensions = require('../../outputs/figures/dimensions')
 const _areas = require('../../outputs/figures/areas')
 const _volumes = require('../../outputs/figures/volumes')
 const _estimates = require('../../outputs/figures/estimates')
 
 const dimensions = _dimensions(defaults, points)
-const areas = _areas(defaults, dimensions, points, 'm2')
+
 
 describe('dimensions', () => {
   it('outputs dimensions in mm', () => {
@@ -26,8 +27,9 @@ describe('dimensions', () => {
 })
 
 describe('areas', () => {
-  it('calculates areas in m²', () => {
-    expect(areas).toEqual({
+  it('calculates areas in mm²', () => {
+    const areas = mutatingMap(_areas(defaults, dimensions, points), Math.round)
+    const expected = mutatingMap({
       internal: {
         floor: 37.676012, // 75.34
         walls: 72.18142209335001, // 88.89
@@ -40,7 +42,8 @@ describe('areas', () => {
         endWall: 14.046202506499998
         // surface: 185.44,
       }
-    })
+    }, (v) => Math.round(v*1000*1000) )
+    expect(areas).toEqual(expected)
   });
   // openings: {
   //   total: 14.66
@@ -60,10 +63,9 @@ describe('areas', () => {
 
 describe('volumes', () => {
   const areas = _areas(defaults, dimensions, points)
-  const volumes = _volumes(defaults, dimensions, points, areas, 'm3')
+  const volumes = mutatingMap(_volumes(defaults, dimensions, points, areas), Math.round)
 
-  it('calculates volumes in m³', () => {
-    expect(volumes).toEqual({
+  const expected = mutatingMap({
       internal: {
         total: 112.83834153894173,
         endWall: 2.660277761668751,
@@ -76,7 +78,10 @@ describe('volumes', () => {
       materials: {
         singleSheet: 0.0535824
       }
-    })
+  }, (v) => Math.round(v*1000*1000*1000) )
+
+  it('calculates volumes', () => {
+    expect(volumes).toEqual(expected)
   });
 })
 

--- a/src/lib/wren/__tests__/outputs/pieces/side.js
+++ b/src/lib/wren/__tests__/outputs/pieces/side.js
@@ -9,7 +9,7 @@ it('generates a side', () => {
     [0, 1500],
   ]
 
-  expect(side(defaults)(points)).toEqual([{
+  expect(side(defaults, points)).toEqual([{
     pts: [[0, 2400], [1200, 2400], [1200, 0], [0, 0]],
     pos: {x: 0, y: 0, z: 0},
     rot: {order: 'ZYX', x: 0, y: 0, z: Math.PI}
@@ -25,7 +25,7 @@ it('generates multiple pieces for a side longer than materials.plywood.maxHeight
     [3900,1500]
   ]
 
-  expect(side(defaults)(points)).toEqual([
+  expect(side(defaults, points)).toEqual([
     {
       pts: [[0, 2400], [1200, 2400], [1200, 0], [0, 0]],
       pos: {x: 0, y: 0, z: 0},

--- a/src/lib/wren/index.js
+++ b/src/lib/wren/index.js
@@ -4,7 +4,9 @@ const _outputs = require('./outputs')
 
 function Wren(overrides) {
   const inputs = merge(defaults, overrides)
+  console.time('wren')
   const outputs = _outputs(inputs)
+  console.timeEnd('wren')
 
   const toSVG = (options) => outputs.formats.svg(options)
 

--- a/src/lib/wren/outputs/cutsheet.js
+++ b/src/lib/wren/outputs/cutsheet.js
@@ -62,7 +62,7 @@ const addPoints = (a, b) => {
   return [ a[0] + b[0], a[1] + b[1] ]
 }
 
-function layoutPartsWithoutOverlap(parts, separation=0.1) {
+function layoutPartsWithoutOverlap(parts, separation=50) {
   // Can make this as complicated as one wants, right up to full-blown nesting...
   // So doing a trivial 1-column vertical layout
   // NOTE: SVG coordinate conventions, downwards = positive Y
@@ -137,8 +137,12 @@ export function layout(pieces, options={}) {
 
 export function exportSVG(layedoutParts, options={}) {
 
+  if (!options.stroke) {
+    options.stroke = 6.0
+  }
+
   const svgPart = (part) => {
-    const style = "fill:none;stroke:#000000;stroke-opacity:1;stroke-width:0.00377953"
+    const style = `fill:none;stroke:#000000;stroke-opacity:1;stroke-width:${options.stroke}`
     return SVG.path(part.geometry.pts, { id: part.id, style })
   }
 

--- a/src/lib/wren/outputs/figures/areas.js
+++ b/src/lib/wren/outputs/figures/areas.js
@@ -73,7 +73,7 @@ const areas = (inputs, dimensions, points) => {
   }
   // console.log(unit(100000, 'mm^2').to('mm^2').value)
 
-  return O.mutatingMap(_areas, v => v/(1000*1000))
+  return _areas
 }
 
 module.exports = areas

--- a/src/lib/wren/outputs/figures/areas.js
+++ b/src/lib/wren/outputs/figures/areas.js
@@ -3,8 +3,6 @@ const Point = require('../../utils/point')
 const roof = require('../../outputs/pieces/bay/side')
 const O = require('../../utils/object')
 
-const { unit } = require('mathjs')
-
 const featureDistance = (points, name) => {
   const indices = profile.sides[name];
   const first = points[indices[0]];
@@ -37,7 +35,7 @@ const area = (points, features, length) => {
 
 const roofArea = (start, end, length) => Point.distance(start, end) * length
 
-const areas = (inputs, dimensions, points, _unit='mm2') => {
+const areas = (inputs, dimensions, points) => {
 
   const inputDimensions = inputs.dimensions
   const iEndWallArea = Clipper.area(Object.values(points.inner))
@@ -75,7 +73,7 @@ const areas = (inputs, dimensions, points, _unit='mm2') => {
   }
   // console.log(unit(100000, 'mm^2').to('mm^2').value)
 
-  return O.mutatingMap(_areas, v => unit(v, 'mm2').toNumber(_unit))
+  return O.mutatingMap(_areas, v => v/(1000*1000))
 }
 
 module.exports = areas

--- a/src/lib/wren/outputs/figures/volumes.js
+++ b/src/lib/wren/outputs/figures/volumes.js
@@ -1,7 +1,6 @@
 const O = require('../../utils/object')
-const { unit } = require('mathjs')
 
-const volumes = (inputs, dimensions, points, areas, _unit="mm3") => {
+const volumes = (inputs, dimensions, points, areas) => {
 
   const inputDimensions = inputs.dimensions
   const m = inputs.materials
@@ -28,7 +27,7 @@ const volumes = (inputs, dimensions, points, areas, _unit="mm3") => {
     }
   }
 
-  return O.mutatingMap(_volumes, v => unit(v, 'mm3').toNumber(_unit))
+  return O.mutatingMap(_volumes, v => v/(1000*1000*1000))
 }
 
 module.exports = volumes

--- a/src/lib/wren/outputs/figures/volumes.js
+++ b/src/lib/wren/outputs/figures/volumes.js
@@ -27,7 +27,7 @@ const volumes = (inputs, dimensions, points, areas) => {
     }
   }
 
-  return O.mutatingMap(_volumes, v => v/(1000*1000*1000))
+  return _volumes
 }
 
 module.exports = volumes

--- a/src/lib/wren/outputs/pieces/bay/index.js
+++ b/src/lib/wren/outputs/pieces/bay/index.js
@@ -2,9 +2,9 @@ const side = require('./side')
 
 const Bay = (points, inputs, index=0) => {
 
-  const halfWidth = ((points.outer.BR[0] - points.outer.BL[0])/2)/1000
-  const bayLength = inputs.dimensions.bayLength/1000
-  const plyThickness = inputs.materials.plywood.depth/1000
+  const halfWidth = (points.outer.BR[0] - points.outer.BL[0])/2
+  const bayLength = inputs.dimensions.bayLength
+  const plyThickness = inputs.materials.plywood.depth
   const bayZ = (bayLength * index) - (bayLength * inputs.dimensions.bays)/2
 
   return {
@@ -15,27 +15,27 @@ const Bay = (points, inputs, index=0) => {
       inner: {
         leftWall: side(inputs,
           [points.inner.TL, points.inner.BL],
-          { x: points.inner.BL[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
+          { x: points.inner.BL[0] - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1]), z: bayZ },
           { y: Math.PI/2 }
         ),
         rightWall: side(inputs,
           [points.inner.TR, points.inner.BR],
-          { x: points.inner.BR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
+          { x: points.inner.BR[0] - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1]), z: bayZ },
           { y: Math.PI/2 }
         ),
         leftRoof: side(inputs,
           [points.inner.TL, points.inner.T],
-          { x: points.inner.TL[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000 + (points.inner.BL[1]-points.inner.TL[1])/1000, z: bayZ },
+          { x: points.inner.TL[0] - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1]) + (points.inner.BL[1]-points.inner.TL[1]), z: bayZ },
           { y: Math.PI/2, z: Math.PI }
         ),
         rightRoof: side(inputs,
           [points.inner.TR, points.inner.T],
-          { x: points.inner.TR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000 + (points.inner.BR[1]-points.inner.TR[1])/1000, z: bayZ-bayLength },
+          { x: points.inner.TR[0] - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1]) + (points.inner.BR[1]-points.inner.TR[1]), z: bayZ-bayLength },
           { y: -Math.PI/2, z: Math.PI }
         ),
         floor: side(inputs,
           [points.inner.BL,points.inner.BR],
-          { x: points.inner.BR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
+          { x: points.inner.BR[0] - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1]), z: bayZ },
           { y: Math.PI/2 }
         )
       },
@@ -43,22 +43,22 @@ const Bay = (points, inputs, index=0) => {
         floor: [/* NOT YET IMPLEMENTED */],
         leftWall: side(inputs,
           [points.outer.TL, points.outer.BL],
-          { x: points.outer.BL[0]/1000 - halfWidth, y: plyThickness, z: bayZ },
+          { x: points.outer.BL[0] - halfWidth, y: plyThickness, z: bayZ },
           { y: Math.PI/2 }
         ),
         rightWall: side(inputs,
           [points.outer.TR, points.outer.BR],
-          { x: points.outer.BR[0]/1000 - halfWidth, y: plyThickness, z: bayZ },
+          { x: points.outer.BR[0] - halfWidth, y: plyThickness, z: bayZ },
           { y: Math.PI/2 }
         ),
         leftRoof: side(inputs,
           [points.outer.TL, points.outer.T],
-          { x: points.outer.TL[0]/1000 - halfWidth, y: (points.outer.BL[1]-points.outer.TL[1])/1000 + plyThickness*2, z: bayZ },
+          { x: points.outer.TL[0] - halfWidth, y: (points.outer.BL[1]-points.outer.TL[1]) + plyThickness*2, z: bayZ },
           { y: Math.PI/2, z: Math.PI }
         ),
         rightRoof: side(inputs,
           [points.outer.TR, points.outer.T],
-          { x: points.outer.TR[0]/1000 - halfWidth, y: (points.outer.BR[1]-points.outer.TR[1])/1000 + plyThickness*2, z: bayZ-bayLength },
+          { x: points.outer.TR[0] - halfWidth, y: (points.outer.BR[1]-points.outer.TR[1]) + plyThickness*2, z: bayZ-bayLength },
           { y: -Math.PI/2, z: Math.PI }
         )
       }

--- a/src/lib/wren/outputs/pieces/bay/index.js
+++ b/src/lib/wren/outputs/pieces/bay/index.js
@@ -2,7 +2,6 @@ const side = require('./side')
 
 const Bay = (points, inputs, index=0) => {
 
-  const s = side(inputs, 'm')
   const halfWidth = ((points.outer.BR[0] - points.outer.BL[0])/2)/1000
   const bayLength = inputs.dimensions.bayLength/1000
   const plyThickness = inputs.materials.plywood.depth/1000
@@ -14,27 +13,27 @@ const Bay = (points, inputs, index=0) => {
     underboards: [],
     sides: {
       inner: {
-        leftWall: s(
+        leftWall: side(inputs,
           [points.inner.TL, points.inner.BL],
           { x: points.inner.BL[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
           { y: Math.PI/2 }
         ),
-        rightWall: s(
+        rightWall: side(inputs,
           [points.inner.TR, points.inner.BR],
           { x: points.inner.BR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
           { y: Math.PI/2 }
         ),
-        leftRoof: s(
+        leftRoof: side(inputs,
           [points.inner.TL, points.inner.T],
           { x: points.inner.TL[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000 + (points.inner.BL[1]-points.inner.TL[1])/1000, z: bayZ },
           { y: Math.PI/2, z: Math.PI }
         ),
-        rightRoof: s(
+        rightRoof: side(inputs,
           [points.inner.TR, points.inner.T],
           { x: points.inner.TR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000 + (points.inner.BR[1]-points.inner.TR[1])/1000, z: bayZ-bayLength },
           { y: -Math.PI/2, z: Math.PI }
         ),
-        floor: s(
+        floor: side(inputs,
           [points.inner.BL,points.inner.BR],
           { x: points.inner.BR[0]/1000 - halfWidth, y: (points.outer.BR[1] - points.inner.BR[1])/1000, z: bayZ },
           { y: Math.PI/2 }
@@ -42,22 +41,22 @@ const Bay = (points, inputs, index=0) => {
       },
       outer: {
         floor: [/* NOT YET IMPLEMENTED */],
-        leftWall: s(
+        leftWall: side(inputs,
           [points.outer.TL, points.outer.BL],
           { x: points.outer.BL[0]/1000 - halfWidth, y: plyThickness, z: bayZ },
           { y: Math.PI/2 }
         ),
-        rightWall: s(
+        rightWall: side(inputs,
           [points.outer.TR, points.outer.BR],
           { x: points.outer.BR[0]/1000 - halfWidth, y: plyThickness, z: bayZ },
           { y: Math.PI/2 }
         ),
-        leftRoof: s(
+        leftRoof: side(inputs,
           [points.outer.TL, points.outer.T],
           { x: points.outer.TL[0]/1000 - halfWidth, y: (points.outer.BL[1]-points.outer.TL[1])/1000 + plyThickness*2, z: bayZ },
           { y: Math.PI/2, z: Math.PI }
         ),
-        rightRoof: s(
+        rightRoof: side(inputs,
           [points.outer.TR, points.outer.T],
           { x: points.outer.TR[0]/1000 - halfWidth, y: (points.outer.BR[1]-points.outer.TR[1])/1000 + plyThickness*2, z: bayZ-bayLength },
           { y: -Math.PI/2, z: Math.PI }

--- a/src/lib/wren/outputs/pieces/bay/side.js
+++ b/src/lib/wren/outputs/pieces/bay/side.js
@@ -9,9 +9,8 @@ const Point = require('../../../utils/point')
 const WrenHelpers = require('../../../utils/wrenhelpers')
 const { merge } = require('lodash')
 const THREE = require('three')
-const { unit } = require('mathjs')
 
-const side = (params, _unit='mm') => ([start, end], pos={ x: 0, y: 0, z: 0 }, rotationOverrides={}) => {
+function side(params, [start, end], pos={ x: 0, y: 0, z: 0 }, rotationOverrides={}) {
 
   const length = Point.distance(start, end)
   const angle = Point.angle(start, end)
@@ -29,22 +28,22 @@ const side = (params, _unit='mm') => ([start, end], pos={ x: 0, y: 0, z: 0 }, ro
   const euler = new THREE.Euler(newRot.x, newRot.y, newRot.z, newRot.order)
   const direction = startPosition.clone().applyEuler(euler).normalize()
 
-  const pieceLengths = WrenHelpers.pieces(length, params.materials.plywood.maxHeight)
+  const pieceLengths = WrenHelpers.pieces(length/1000, params.materials.plywood.maxHeight/1000)
 
   let allPieces = []
   for (let i = 0; i < pieceLengths.length; i++) {
     const pieceLength = pieceLengths[i]
     const pts = [
       [0, pieceLength],
-      [params.dimensions.bayLength, pieceLength],
-      [params.dimensions.bayLength, 0],
+      [params.dimensions.bayLength/1000, pieceLength],
+      [params.dimensions.bayLength/1000, 0],
       [0, 0]
-    ].map(pts => pts.map(pt => unit(pt, 'mm').toNumber(_unit) ))
+    ]
 
     let newPos = startPosition.clone().add(
       new THREE.Vector3(
         0,
-        unit(params.materials.plywood.maxHeight*i, 'mm').toNumber(_unit),
+        (params.materials.plywood.maxHeight/1000)*i,
         0
       ).applyEuler(euler)
     )

--- a/src/lib/wren/outputs/pieces/bay/side.js
+++ b/src/lib/wren/outputs/pieces/bay/side.js
@@ -28,22 +28,22 @@ function side(params, [start, end], pos={ x: 0, y: 0, z: 0 }, rotationOverrides=
   const euler = new THREE.Euler(newRot.x, newRot.y, newRot.z, newRot.order)
   const direction = startPosition.clone().applyEuler(euler).normalize()
 
-  const pieceLengths = WrenHelpers.pieces(length/1000, params.materials.plywood.maxHeight/1000)
+  const pieceLengths = WrenHelpers.pieces(length, params.materials.plywood.maxHeight)
 
   let allPieces = []
   for (let i = 0; i < pieceLengths.length; i++) {
     const pieceLength = pieceLengths[i]
     const pts = [
       [0, pieceLength],
-      [params.dimensions.bayLength/1000, pieceLength],
-      [params.dimensions.bayLength/1000, 0],
+      [params.dimensions.bayLength, pieceLength],
+      [params.dimensions.bayLength, 0],
       [0, 0]
     ]
 
     let newPos = startPosition.clone().add(
       new THREE.Vector3(
         0,
-        (params.materials.plywood.maxHeight/1000)*i,
+        (params.materials.plywood.maxHeight)*i,
         0
       ).applyEuler(euler)
     )

--- a/src/lib/wren/outputs/pieces/frame/fin.js
+++ b/src/lib/wren/outputs/pieces/frame/fin.js
@@ -2,8 +2,6 @@
 
 const Point = require('../../../utils/point')
 const List = require('../../../utils/list')
-const { compose } = require('ramda')
-const { curry, zipObject } = require('lodash')
 
 const draw = points => {
   const arrayLength = Object.values(points.outer).length
@@ -25,16 +23,12 @@ const draw = points => {
   return shapes
 }
 
-const returnWithMidpoints = ([start,end]) => {
-  return ([start, Point.midpoint(start,end), end])
+function withMidpoints([start, end]) {
+  const mid = Point.midpoint(start,end)
+  return { 'START': start, 'END': end, 'MID': mid }
 }
 
 const fin = points => {
-
-  const withMidpoints = compose(
-    curry(zipObject)(['START', 'MID', 'END']),
-    returnWithMidpoints,
-  )
 
   const pointsWithMidPoints = {
     outer: List.loopifyInPairs(Object.values(points.outer)).map(withMidpoints),

--- a/src/lib/wren/outputs/pieces/frame/index.js
+++ b/src/lib/wren/outputs/pieces/frame/index.js
@@ -2,13 +2,13 @@ const fin = require('./fin')
 
 const Frame = (points, inputs, index=0) => {
 
-  const bayLength = inputs.dimensions.bayLength/1000
+  const bayLength = inputs.dimensions.bayLength
   const frameZ = (bayLength * (index-1)) - (bayLength * inputs.dimensions.bays)/2
-  const frameX = -(inputs.dimensions.width/1000 + inputs.dimensions.finDepth/1000)/2
-  const frameY = (inputs.dimensions.roofApexHeight/1000) + inputs.dimensions.beamWidth/1000
+  const frameX = -(inputs.dimensions.width + inputs.dimensions.finDepth)/2
+  const frameY = (inputs.dimensions.roofApexHeight) + inputs.dimensions.beamWidth
 
   const finsGroup = fin(points).map(piece => ({
-    pts: piece.map( ([x,y]) => ([x/1000,y/1000]) ),
+    pts: piece,
     pos: { x: frameX, y: frameY, z: frameZ },
     rot: { x: Math.PI, y: 0, z: 0, order: 'XYZ' }
   }))

--- a/src/svgnest.js
+++ b/src/svgnest.js
@@ -70,9 +70,10 @@ function runSvgNest(svgData, binId, options, callback) {
   options.maxTime = options.maxTime || 60.0; // seconds
   options.SvgNest = options.SvgNest || {};
 
+  // All dimensions in millimeters
   var config = {
-    spacing: 0.012, // give space for milling bit
-    curveTolerance: 0.005,
+    spacing: 12, // give space for milling bit
+    curveTolerance: 5,
     rotations: 4,
     populationSize: 10,
     mutationRate: 10,


### PR DESCRIPTION
These changes speed up calculations between 5-10x, occationally more.

![wikihouse-perf-avoids](https://user-images.githubusercontent.com/45185/29693666-6207c93c-8937-11e7-9bae-cb480cf1118e.png)
Measurements with Webworkers off, since this gives more consistent results and easier profiling.

TODO: Fix up tests, they currently expect a mix of millimeter and meters...

After these changes the majority of time is spent in 
1) Calculating inset/offset of the points on the building polygon. This is suprising, since there are only a small number of points. Possibly lots to gain from a simpler algorithm (out-of-scope here)
2) Applying the rotation of sheets for the bays. Probably not worth doing anything about yet